### PR TITLE
docs: fix format of json data in body

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ output {
 curl -XPOST -D- "http://localhost:5601/api/saved_objects/index-pattern" \
     -H "Content-Type: application/json" \
     -H "kbn-version: 6.1.0" \
-    -d "{'attributes':{'title':'logstash-*','timeFieldName':'@timestamp'}}"
+    -d '{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}'
 ```
 
 如果你是 Windows 用戶，請用其他方法，雖然 Windows 也有 curl，但我裝上去執行指令，

--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ curl -XPOST -D- "http://localhost:5601/api/saved_objects/index-pattern" \
     -d '{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}'
 ```
 
+如果上面的指令有報有關json格式錯誤的問題，也可以試試看將最後一行改為：
+```cmd
+    -d "{'attributes':{'title':'logstash-*','timeFieldName':'@timestamp'}}"
+```
+
 如果你是 Windows 用戶，請用其他方法，雖然 Windows 也有 curl，但我裝上去執行指令，
 
 他都會報錯說 josn格式錯誤，所以我直接改用 [Postman](https://www.getpostman.com/)


### PR DESCRIPTION
好像是 JSON 不支援單引號，要使用單引號好像要 JSON 5 才支援的樣子。
剛剛在 Ubuntu 上嘗試，原先的寫法 Ubuntu 也不行，改成這樣就可以了。